### PR TITLE
Fix deprecated bundler warning

### DIFF
--- a/hieracles-0.4.2-bundix/Gemfile
+++ b/hieracles-0.4.2-bundix/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org' do
-  gem 'hieracles'
-end
+source 'https://rubygems.org'
+
+gem 'hieracles'

--- a/hieracles-0.4.2-patched/Gemfile
+++ b/hieracles-0.4.2-patched/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org' do
-  gem 'hieracles'
-end
+source 'https://rubygems.org'
+
+gem 'hieracles'

--- a/hieracles-0.4.2-patched/Gemfile.lock
+++ b/hieracles-0.4.2-patched/Gemfile.lock
@@ -1,7 +1,4 @@
 GEM
-  specs:
-
-GEM
   remote: https://rubygems.org/
   specs:
     awesome_print (1.9.2)
@@ -22,7 +19,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  hieracles!
+  hieracles
 
 BUNDLED WITH
    2.2.33

--- a/hieracles-0.4.2/Gemfile
+++ b/hieracles-0.4.2/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org' do
-  gem 'hieracles'
-end
+source 'https://rubygems.org'
+
+gem 'hieracles'

--- a/hieracles-0.4.2/Gemfile.lock
+++ b/hieracles-0.4.2/Gemfile.lock
@@ -1,7 +1,4 @@
 GEM
-  specs:
-
-GEM
   remote: https://rubygems.org/
   specs:
     awesome_print (1.9.2)
@@ -22,7 +19,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  hieracles!
+  hieracles
 
 BUNDLED WITH
    2.2.33

--- a/hieracles-0.4.3-shell/README.md
+++ b/hieracles-0.4.3-shell/README.md
@@ -10,6 +10,11 @@ It's possible to use hieracles 0.4.3 directly by using a Nix Shell.
 $ git clone https://github.com/Gandi/hieracles.git
 $ cd hieracles
 
+# Need to patch Gemfile to avoir a DEPRECATED warning
+$ cat Gemfile
+source 'https://rubygems.org'
+gem 'hieracles'
+
 # Bundler version will be updated
 $ nix-shell -p bundler bundix --run 'bundle lock && bundix'
 $ cat << EOF > shell.nix


### PR DESCRIPTION
This PR aims to fix a DEPRECATED warning message when using hieracles such as:

```
$ hieracles info herloom.lab.local
[DEPRECATED] This Gemfile does not include an explicit global source. Not using an explicit global source may result in a different lockfile being generated depending on the gems you have installed locally before bundler is run. Instead, define a global source in your Gemfile like this: source "https://rubygems.org"
```